### PR TITLE
Tidy CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@ body {
 .contact {
     display: flex;
     border-bottom: 1px solid black;
-    line-height: 64px;
+    line-height: 2.5;
     font-size: 1.5em;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@ body {
 }
 
 .contact {
-    display:flex;
+    display: flex;
     border-bottom: 1px solid black;
     line-height: 64px;
     font-size: 1.5em;


### PR DESCRIPTION
Apparently no space after the colon in our CSS is a big no, no
(personally I write it without a space). Hard for me to break the habit.

Always good to keep type units relative where possible.